### PR TITLE
In the "réseau" widget, change state management and add sort on systems state

### DIFF
--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -895,10 +895,15 @@ class Freebox_OSCmd extends cmd {
 					$this->setConfiguration('host_type',$result['host_type']);
 					$this->save();
 					if (isset($result['active'])) {
-						if ($result['active'] == 'true')
-							$return=1;
-						else
-							$return=0;
+						if ($result['active'] == 'true') {
+                            $this->setOrder($this->getOrder() % 1000);
+                            $this->save();
+                            $return = 1;
+                        } else {
+                            $this->setOrder($this->getOrder() % 1000 + 1000);
+                            $this->save();
+                            $return = 0;
+                        }
 					} else {
 						$return=false;
 					}

--- a/core/template/dashboard/cmd.info.binary.Freebox_OS_Reseau.html
+++ b/core/template/dashboard/cmd.info.binary.Freebox_OS_Reseau.html
@@ -57,10 +57,13 @@
 </div>
 
 <script>
-	if('#state#'!=''&&'#state#'!='0')
-		$(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-#host_type#-1');
-	else
-		$(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-#host_type#-0');
+	if('#state#'!=''&&'#state#'!='0') {
+        $(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-host-1');
+        $(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-#host_type#-1');
+    } else {
+        $(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-host-0');
+        $(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-#host_type#-0');
+    }
 	$(".cmd[data-cmd_id=#id#]").on("click", function() {
 		$('#md_modal').dialog({
 			title: "Parametre de l'équipement Reseau",

--- a/core/template/mobile/cmd.info.binary.Freebox_OS_Reseau.html
+++ b/core/template/mobile/cmd.info.binary.Freebox_OS_Reseau.html
@@ -50,14 +50,20 @@
 .lan-workstation-0{background-position:0 -1140px}
 .lan-workstation-1{background-position:0 -180px}
 </style>
-	<div class="lan-host-img lan-#host_type#-#state#" aria-label="#name#"></div>
+	<div class="lan-host-img aria-label="#name#"></div>
     <div class="lan-host-name">#name#</div>
     <div class="lan-host-vendor">#IPV4#</div>
     <!--div class="lan-host-vendor">#IPV6#</div-->
 </div>
 
 <script>
-	
+    if('#state#'!=''&&'#state#'!='0') {
+        $(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-host-1');
+        $(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-#host_type#-1');
+    } else {
+        $(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-host-0');
+        $(".cmd[data-cmd_id=#id#] .lan-host-img").addClass('lan-#host_type#-0');
+    }
 	$(".cmd[data-cmd_id=#id#]").on("click", function() {
 		$('#md_modal').dialog({
 			title: "Parametre de l'équipement Reseau",


### PR DESCRIPTION
Dans le réseau, les systèmes éteints n'étaient pas grisé. 
J'ai de plus ajouté un tri pour avoir les systèmes UP en premier.