### PR TITLE
Retourne 0 pour les équipements non présent au démarrage du daemon

### DIFF
--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -900,7 +900,7 @@ class Freebox_OSCmd extends cmd {
 						else
 							$return=0;
 					} else {
-						$return=false;
+						$return=0;
 					}
 				}
 			break;


### PR DESCRIPTION
Retourne 0 pour les équipements non présents au démarrage du daemon.
Au démarrage si l'équipement n'est pas présent sur le réseau au démarrage (cache vide aussi), la valeur retourné est "" ce qui est difficile à gérer. 
Ici on retourne 0 indiquant que l'équipement n'est pas la, cela évite un système à 3 valeurs 1/0/""