### PR TITLE
Update Freebox_OS.class.php

### DIFF
--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -595,7 +595,7 @@ class Freebox_OSCmd extends cmd {
 			default:
 				switch ($this->getSubType()) {
 					case 'slider':    
-						$parametre['value'] = $_options['slider'];
+						$parametre['value'] = (int)$_options['slider'];
 					break;
 					case 'color':
 						$parametre['value'] = $_options['color'];


### PR DESCRIPTION
Cast la valeur du slider sinon on envoie la chaine de caractères avec les "" autour de la valeur, la freebox renvoie une erreur de json incorrect.