### PR TITLE
Pour partage d'expérience, ne pas merger en l'état

### DIFF
--- a/core/class/FreeboxAPI.class.php
+++ b/core/class/FreeboxAPI.class.php
@@ -285,14 +285,17 @@ class FreeboxAPI{
 							$Tile->AddCommande($Commande['label'],$Commande['ep_id'],"action",'other');
                               			break;
                               			case "int":
-							foreach(str_split($Commande['ui']['access']) as $access){
-								if($access == "r"){
-									$Tile->AddCommande('info_'. $Commande['label'],$Commande['ep_id'],"info",'numeric');
-									$Tile->checkAndUpdateCmd($Commande['ep_id'],$Commande['value']);
-								}
-								if($access == "w"){
-									$Tile->AddCommande('action_'. $Commande['label'],$Commande['ep_id'],"action",'slider');
-								}
+							if($Commande['ui']['access'] == "r"){
+								$Tile->AddCommande('info_'. $Commande['label'],$Commande['ep_id'],"info",'numeric');
+								$Tile->checkAndUpdateCmd($Commande['ep_id'],$Commande['value']);
+							}
+							if($Commande['ui']['access'] == "w"){
+								$Tile->AddCommande('action_'. $Commande['label'],$Commande['ep_id'],"action",'slider');
+							}
+                                			if($Commande['ui']['access'] == "rw"){
+								$Tile->AddCommande('info_'. $Commande['label'],$Commande['ep_id'],"info",'numeric');
+								$Tile->checkAndUpdateCmd($Commande['ep_id'],$Commande['value']);
+                                  				$Tile->AddCommande('action_'. $Commande['label'],$Commande['ep_id']."_action","action",'slider');
 							}
                               			break;
                               			case "bool":


### PR DESCRIPTION
Essai de modif pour avoir les 2 commandes infos et action dans le cas d'un accès rw sur la freebox et très étonnamment ça : 

$Tile->AddCommande('action_'. $Commande['label'],$Commande['ep_id']."_action","action",'slider');

ça marche. C'est à dire en modifiant le logical Id de la commande action. Je ne comprend pas pourquoi mais en actionnant le slider mes volet répondent alors que l'ep_id de la commande côté freebox est bizarre. Voilà la réponse de la Freebox : 

[2019-10-08 22:50:45][DEBUG] : Connexion sur la freebox pour action_Consigne douverture
[2019-10-08 22:50:45][DEBUG] : Connexion PUT sur la l'adresse mafreebox.free.fr/api/v6/home/endpoints/14/3_action/({"value":100})
[2019-10-08 22:50:45][DEBUG] : {   "success" : true }

Bien sûr le retour d'état fonctionne sur la commande info mais pas sur le slider dans ce cas.