### PR TITLE
Corrections Bugs

### DIFF
--- a/core/ajax/Freebox_OS.ajax.php
+++ b/core/ajax/Freebox_OS.ajax.php
@@ -12,7 +12,7 @@ try {
 			$EqLogic = eqLogic::byLogicalId(init('id'), 'camera');
 			if (!is_object($EqLogic)) {
 				$url = explode('@', explode('://', init('url'))[1]);
-
+				log::add('Freebox_OS', 'debug', '┌───────── Création de la caméra : ' . init('name'));
 				$username = explode(':', $url[0])[0];
 				$password = explode(':', $url[0])[1];
 
@@ -30,11 +30,23 @@ try {
 				$EqLogic->setconfiguration("protocole", "http");
 				$EqLogic->setconfiguration("ip", $ip);
 				$EqLogic->setconfiguration("port", $port);
+				log::add('Freebox_OS', 'debug', '│ IP : ' . $ip . ' - Port : ' . $port);
 				$EqLogic->setconfiguration("username", $username);
 				$EqLogic->setconfiguration("password", $password);
-				$EqLogic->setconfiguration("urlStream", "img/snapshot.cgi?size=4&quality=1");
-				$EqLogic->setconfiguration('cameraStreamAccessUrl', init('url'));
+				$EqLogic->setconfiguration("videoFramerate", 15);
+				$EqLogic->setconfiguration("applyDevice", "Freebox.RocketCam");
+				$URL_snaphot = "img/snapshot.cgi?size=4&quality=1";
+				$EqLogic->setconfiguration("urlStream", $URL_snaphot);
+				$URLrtsp = init('url');
+				$URLrtsp = str_replace("http", "rtsp", $URLrtsp);
+				$URLrtsp = $URLrtsp . '/live';
+				$URLrtsp = str_replace($ip, "#ip#", $URLrtsp);
+				$URLrtsp = str_replace($username, "#username#", $URLrtsp);
+				$URLrtsp = str_replace($password, "#password#", $URLrtsp);
+				log::add('Freebox_OS', 'debug', '│ URL du flux : ' . $URLrtsp . ' - URL de snaphot : ' . $URL_snaphot);
+				$EqLogic->setconfiguration('cameraStreamAccessUrl', $URLrtsp);
 				$EqLogic->save();
+				log::add('Freebox_OS', 'debug', '└─────────');
 			}
 			ajax::success(true);
 			break;

--- a/core/ajax/Freebox_OS.ajax.php
+++ b/core/ajax/Freebox_OS.ajax.php
@@ -39,7 +39,7 @@ try {
 				$EqLogic->setconfiguration("urlStream", $URL_snaphot);
 				$URLrtsp = init('url');
 				$URLrtsp = str_replace("http", "rtsp", $URLrtsp);
-				$URLrtsp = $URLrtsp . '/live';
+				$URLrtsp = str_replace("/stream.m3u8", "/live", $URLrtsp);
 				$URLrtsp = str_replace($ip, "#ip#", $URLrtsp);
 				$URLrtsp = str_replace($username, "#username#", $URLrtsp);
 				$URLrtsp = str_replace($password, "#password#", $URLrtsp);

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -202,9 +202,16 @@ class Freebox_OS extends eqLogic
 	{
 		$FreeboxAPI = new FreeboxAPI();
 		$HomeAdapters = self::AddEqLogic('Home Adapters', 'HomeAdapters', 'default', false, null, null);
+		if (version_compare(jeedom::version(), "4", "<")) {
+			log::add('Freebox_OS', 'debug', '│ Application des Widgets ou Icônes pour le core V3 ');
+			$templatecore_V4 = null;
+		} else {
+			log::add('Freebox_OS', 'debug', '│ Application des Widgets ou Icônes pour le core V4');
+			$templatecore_V4  = 'core::';
+		};
 		foreach ($FreeboxAPI->getHomeAdapters() as $Equipement) {
 			if ($Equipement['label'] != '') {
-				$HomeAdapters->AddCommand($Equipement['label'], $Equipement['id'], 'info', 'binary', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', null, 0, false);
+				$HomeAdapters->AddCommand($Equipement['label'], $Equipement['id'], 'info', 'binary', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', null, 0, false);
 				if ($Equipement['status'] == 'active') {
 					$HomeAdapters_value = 1;
 				} else {
@@ -219,6 +226,13 @@ class Freebox_OS extends eqLogic
 		$FreeboxAPI = new FreeboxAPI();
 		self::AddEqLogic('Home Adapters', 'HomeAdapters', 'default', false, null, null);
 		//$_logicalId_OLD = null;
+		if (version_compare(jeedom::version(), "4", "<")) {
+			log::add('Freebox_OS', 'debug', '│ Application des Widgets ou Icônes pour le core V3 ');
+			$templatecore_V4 = null;
+		} else {
+			log::add('Freebox_OS', 'debug', '│ Application des Widgets ou Icônes pour le core V4');
+			$templatecore_V4  = 'core::';
+		};
 		foreach ($FreeboxAPI->getTiles() as $Equipement) {
 			if ($Equipement['type'] != 'camera') {
 				if ($Equipement['type'] == 'alarm_sensor' || $Equipement['type'] == 'alarm_control' || $Equipement['type'] == 'alarm_remote') {
@@ -319,11 +333,11 @@ class Freebox_OS extends eqLogic
 									}
 									if ($Equipement['action'] == "store_slider") {
 										$generic_type = 'FLAP_STATE';
-										$Templatecore = 'core::shutter';
+										$Templatecore = $templatecore_V4 . 'shutter';
 										$_min = '0';
 										$_max = 100;
 									} elseif ($Command['name'] == "luminosity" || ($Equipement['action'] == "color_picker" && $Command['name'] == 'v')) {
-										$Templatecore_A = 'core::light';
+										$Templatecore_A = $templatecore_V4 . 'light';
 										$_min = '0';
 										$_max = 255;
 										$generic_type = 'LIGHT_SET_COLOR';
@@ -389,21 +403,21 @@ class Freebox_OS extends eqLogic
 								if ($access == "r") {
 									if ($Equipement['action'] == "store") {
 										$generic_type = 'FLAP_STATE';
-										$Templatecore = 'core::shutter';
+										$Templatecore = $templatecore_V4 . 'shutter';
 									} elseif ($Equipement['type'] == "alarm_sensor" && $Command['name'] == 'cover') {
 										$generic_type = 'SABOTAGE';
 										$Templatecore = null;
 										$invertBinary = 1;
 									} elseif ($Equipement['type'] == "alarm_sensor" && $Command['name'] == 'trigger' && $Command['label'] != 'Détection') {
 										$generic_type = 'OPENING';
-										$Templatecore = 'core::door';
+										$Templatecore = $templatecore_V4 . 'door';
 									} elseif ($Equipement['type'] == "alarm_sensor" && $Command['name'] == 'trigger' && $Command['label'] == 'Détection') {
 										$generic_type = 'PRESENCE';
-										$Templatecore = 'core::presence';
+										$Templatecore = $templatecore_V4 . 'presence';
 										$invertBinary = 0;
 									} elseif ($Command['label'] == 'Enclenché' || ($Command['name'] == 'switch' && $Equipement['action'] == 'toggle')) {
 										$generic_type = 'LIGHT_STATE';
-										$Templatecore = 'core::light';
+										$Templatecore = $templatecore_V4 . 'light';
 										$invertBinary = 0;
 										$IsVisible = 0;
 										$Label = 'Etat';
@@ -585,6 +599,13 @@ class Freebox_OS extends eqLogic
 	{
 		self::AddEqLogic('Réseau', 'Reseau', 'default', false, null, null);
 		self::AddEqLogic('Disque Dur', 'Disque', 'default', false, null, null);
+		if (version_compare(jeedom::version(), "4", "<")) {
+			log::add('Freebox_OS', 'debug', '│ Application des Widgets ou Icônes pour le core V3 ');
+			$templatecore_V4 = null;
+		} else {
+			log::add('Freebox_OS', 'debug', '│ Application des Widgets ou Icônes pour le core V4');
+			$templatecore_V4  = 'core::';
+		};
 		// ADSL
 		log::add('Freebox_OS', 'debug', '┌───────── Ajout des commandes : ADSL');
 		if (version_compare(jeedom::version(), "4", "<")) {
@@ -595,12 +616,12 @@ class Freebox_OS extends eqLogic
 			$updateiconeADSL = false;
 		};
 		$ADSL = self::AddEqLogic('ADSL', 'ADSL', 'default', false, null, null);
-		$ADSL->AddCommand('Freebox rate down', 'rate_down', 'info', 'numeric', 'core::badge', 'Ko/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 1, '0', $updateiconeADSL);
-		$ADSL->AddCommand('Freebox rate up', 'rate_up', 'info', 'numeric', 'core::badge', 'Ko/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 2, '0', $updateiconeADSL);
-		$ADSL->AddCommand('Freebox bandwidth up', 'bandwidth_up', 'info', 'numeric', 'core::badge', 'Mb/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 3, '0', $updateiconeADSL);
-		$ADSL->AddCommand('Freebox bandwidth down', 'bandwidth_down', 'info', 'numeric', 'core::badge', 'Mb/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 4, '0', $updateiconeADSL);
-		$ADSL->AddCommand('Freebox media', 'media', 'info', 'string', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 5, '0', $updateiconeADSL);
-		$ADSL->AddCommand('Freebox state', 'state', 'info', 'string', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 6, '0', $updateiconeADSL);
+		$ADSL->AddCommand('Freebox rate down', 'rate_down', 'info', 'numeric', $templatecore_V4 . 'badge', 'Ko/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 1, '0', $updateiconeADSL);
+		$ADSL->AddCommand('Freebox rate up', 'rate_up', 'info', 'numeric', $templatecore_V4 . 'badge', 'Ko/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 2, '0', $updateiconeADSL);
+		$ADSL->AddCommand('Freebox bandwidth up', 'bandwidth_up', 'info', 'numeric', $templatecore_V4 . 'badge', 'Mb/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 3, '0', $updateiconeADSL);
+		$ADSL->AddCommand('Freebox bandwidth down', 'bandwidth_down', 'info', 'numeric', $templatecore_V4 . 'badge', 'Mb/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 4, '0', $updateiconeADSL);
+		$ADSL->AddCommand('Freebox media', 'media', 'info', 'string', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 5, '0', $updateiconeADSL);
+		$ADSL->AddCommand('Freebox state', 'state', 'info', 'string', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 6, '0', $updateiconeADSL);
 		log::add('Freebox_OS', 'debug', '└─────────');
 		// System
 		log::add('Freebox_OS', 'debug', '┌───────── Ajout des commandes : Système');
@@ -620,17 +641,17 @@ class Freebox_OS extends eqLogic
 			$updateiconeSystem = false;
 		};
 		$System = self::AddEqLogic('Système', 'System', 'default', false, null, null);
-		$System->AddCommand('Update', 'update', 'action', 'other', 'core::line', null, null, 1, 'default', 'default', 0, $iconeUpdate, 0, 'default', 'default', 'default', 11, '0', $updateiconeSystem);
-		$System->AddCommand('Reboot', 'reboot', 'action', 'other',  'core::line', null, null, 1, 'default', 'default', 0, $iconeReboot, 0, 'default', 'default', 'default', 12, '0', $updateiconeSystem);
-		$System->AddCommand('Freebox firmware version', 'firmware_version', 'info', 'string', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 1, '0', $updateiconeSystem);
-		$System->AddCommand('Mac', 'mac', 'info', 'string',  'core::line', null, null, 0, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 2, '0', $updateiconeSystem);
-		$System->AddCommand('Allumée depuis', 'uptime', 'info', 'string',  'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 3, '0', $updateiconeSystem);
-		$System->AddCommand('board name', 'board_name', 'info', 'string',  'core::line', null, null, 0, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 4, '0', $updateiconeSystem);
-		$System->AddCommand('serial', 'serial', 'info', 'string',  'core::line', null, null, 0, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 5, '0', $updateiconeSystem);
-		$System->AddCommand('Vitesse ventilateur', 'fan_rpm', 'info', 'numeric', 'core::line', 'tr/min', null, 1, 'default', 'default', 0, $iconefan, 0, "0", 5000, 'default', 6, '0', $updateiconeSystem);
-		$System->AddCommand('temp cpub', 'temp_cpub', 'info', 'numeric', 'core::line', '°C', null, 1, 'default', 'default', 0, $iconetemp, 0, "0", 100, 'default', 7, '0', $updateiconeSystem);
-		$System->AddCommand('temp cpum', 'temp_cpum', 'info', 'numeric', 'core::line', '°C', null, 1, 'default', 'default', 0, $iconetemp, 0, "0", 100, 'default', 8, '0', $updateiconeSystem);
-		$System->AddCommand('temp sw', 'temp_sw', 'info', 'numeric', 'core::line', '°C', null, 1, 'default', 'default', 0, $iconetemp, 0, "0", 100, 'default', 9, '0', $updateiconeSystem);
+		$System->AddCommand('Update', 'update', 'action', 'other', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, $iconeUpdate, 0, 'default', 'default', 'default', 11, '0', $updateiconeSystem);
+		$System->AddCommand('Reboot', 'reboot', 'action', 'other',  $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, $iconeReboot, 0, 'default', 'default', 'default', 12, '0', $updateiconeSystem);
+		$System->AddCommand('Freebox firmware version', 'firmware_version', 'info', 'string', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 1, '0', $updateiconeSystem);
+		$System->AddCommand('Mac', 'mac', 'info', 'string',  $templatecore_V4 . 'line', null, null, 0, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 2, '0', $updateiconeSystem);
+		$System->AddCommand('Allumée depuis', 'uptime', 'info', 'string',  $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 3, '0', $updateiconeSystem);
+		$System->AddCommand('board name', 'board_name', 'info', 'string',  $templatecore_V4 . 'line', null, null, 0, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 4, '0', $updateiconeSystem);
+		$System->AddCommand('serial', 'serial', 'info', 'string',  $templatecore_V4 . 'line', null, null, 0, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 5, '0', $updateiconeSystem);
+		$System->AddCommand('Vitesse ventilateur', 'fan_rpm', 'info', 'numeric', $templatecore_V4 . 'line', 'tr/min', null, 1, 'default', 'default', 0, $iconefan, 0, "0", 5000, 'default', 6, '0', $updateiconeSystem);
+		$System->AddCommand('temp cpub', 'temp_cpub', 'info', 'numeric', $templatecore_V4 . 'line', '°C', null, 1, 'default', 'default', 0, $iconetemp, 0, "0", 100, 'default', 7, '0', $updateiconeSystem);
+		$System->AddCommand('temp cpum', 'temp_cpum', 'info', 'numeric', $templatecore_V4 . 'line', '°C', null, 1, 'default', 'default', 0, $iconetemp, 0, "0", 100, 'default', 8, '0', $updateiconeSystem);
+		$System->AddCommand('temp sw', 'temp_sw', 'info', 'numeric', $templatecore_V4 . 'line', '°C', null, 1, 'default', 'default', 0, $iconetemp, 0, "0", 100, 'default', 9, '0', $updateiconeSystem);
 		$System->AddCommand('Redirection de ports', 'port_forwarding', 'action', 'message', null, null, null, 0, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 10, '0', $updateiconeSystem);
 
 		log::add('Freebox_OS', 'debug', '└─────────');
@@ -702,18 +723,18 @@ class Freebox_OS extends eqLogic
 			$updateiconeDownloads = false;
 		};
 		$Downloads = self::AddEqLogic('Téléchargements', 'Downloads', 'multimedia', false, null, null);
-		$Downloads->AddCommand('Nombre de tâche(s)', 'nb_tasks', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 1, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Nombre de tâche(s) active', 'nb_tasks_active', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 2, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Nombre de tâche(s) en extraction', 'nb_tasks_extracting', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 3, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Nombre de tâche(s) en réparation', 'nb_tasks_repairing', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 4, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Nombre de tâche(s) en vérification', 'nb_tasks_checking', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 5, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Nombre de tâche(s) en attente', 'nb_tasks_queued', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 6, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Nombre de tâche(s) en erreur', 'nb_tasks_error', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 7, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Nombre de tâche(s) stoppée(s)', 'nb_tasks_stopped', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 8, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Nombre de tâche(s) terminée(s)', 'nb_tasks_done', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 9, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Téléchargement en cours', 'nb_tasks_downloading', 'info', 'numeric', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 10, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Vitesse réception', 'rx_rate', 'info', 'numeric', 'core::badge', 'Mo/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 11, '0', $updateiconeDownloads);
-		$Downloads->AddCommand('Vitesse émission', 'tx_rate', 'info', 'numeric', 'core::badge', 'Mo/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 12, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Nombre de tâche(s)', 'nb_tasks', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 1, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Nombre de tâche(s) active', 'nb_tasks_active', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 2, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Nombre de tâche(s) en extraction', 'nb_tasks_extracting', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 3, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Nombre de tâche(s) en réparation', 'nb_tasks_repairing', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 4, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Nombre de tâche(s) en vérification', 'nb_tasks_checking', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 5, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Nombre de tâche(s) en attente', 'nb_tasks_queued', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 6, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Nombre de tâche(s) en erreur', 'nb_tasks_error', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 7, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Nombre de tâche(s) stoppée(s)', 'nb_tasks_stopped', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 8, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Nombre de tâche(s) terminée(s)', 'nb_tasks_done', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 9, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Téléchargement en cours', 'nb_tasks_downloading', 'info', 'numeric', $templatecore_V4 . 'line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 10, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Vitesse réception', 'rx_rate', 'info', 'numeric', $templatecore_V4 . 'badge', 'Mo/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 11, '0', $updateiconeDownloads);
+		$Downloads->AddCommand('Vitesse émission', 'tx_rate', 'info', 'numeric', $templatecore_V4 . 'badge', 'Mo/s', null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', 12, '0', $updateiconeDownloads);
 		$Downloads->AddCommand('Start DL', 'start_dl', 'action', 'other', null, null, null, 1, 'default', 'default', 0, $iconeDownloadsOn, 0, 'default', 'default', 'default', 13, '0', $updateiconeDownloads);
 		$Downloads->AddCommand('Stop DL', 'stop_dl', 'action', 'other', null, null, null, 1, 'default', 'default', 0, $iconeDownloadsOff, 0, 'default', 'default', 'default', 14, '0', $updateiconeDownloads);
 		log::add('Freebox_OS', 'debug', '└─────────');

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -96,7 +96,7 @@ class Freebox_OS extends eqLogic
 		$cron->run();
 		return $cron;
 	}
-	public static function AddEqLogic($Name, $_logicalId, $category, $tiles, $eq_type, $eq_action)
+	public static function AddEqLogic($Name, $_logicalId, $category = null, $tiles, $eq_type, $eq_action)
 	{
 		$EqLogic = self::byLogicalId($_logicalId, 'Freebox_OS');
 		if (!is_object($EqLogic)) {
@@ -201,18 +201,23 @@ class Freebox_OS extends eqLogic
 	public static function addHomeAdapters()
 	{
 		$FreeboxAPI = new FreeboxAPI();
-		$HomeAdapters = self::AddEqLogic('Home Adapters', 'HomeAdapters', 'default', null, null);
+		$HomeAdapters = self::AddEqLogic('Home Adapters', 'HomeAdapters', 'default', false, null, null);
 		foreach ($FreeboxAPI->getHomeAdapters() as $Equipement) {
 			if ($Equipement['label'] != '') {
-				$HomeAdapters->AddCommand($Equipement['label'], $Equipement['id'], 'info', 'binary', null, null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', null, 0, false);
-				$HomeAdapters->checkAndUpdateCmd($Equipement['id'], $Equipement['status']);
+				$HomeAdapters->AddCommand($Equipement['label'], $Equipement['id'], 'info', 'binary', 'core::line', null, null, 1, 'default', 'default', 0, null, 0, 'default', 'default', 'default', null, 0, false);
+				if ($Equipement['status'] == 'active') {
+					$HomeAdapters_value = 1;
+				} else {
+					$HomeAdapters_value = 0;
+				}
+				$HomeAdapters->checkAndUpdateCmd($Equipement['id'], $HomeAdapters_value);
 			}
 		}
 	}
 	public static function addTiles()
 	{
 		$FreeboxAPI = new FreeboxAPI();
-		self::AddEqLogic('Home Adapters', 'HomeAdapters', 'default', null, null); // Fonction déplacer sur Tiles
+		self::AddEqLogic('Home Adapters', 'HomeAdapters', 'default', false, null, null);
 		//$_logicalId_OLD = null;
 		foreach ($FreeboxAPI->getTiles() as $Equipement) {
 			if ($Equipement['type'] != 'camera') {
@@ -1015,7 +1020,12 @@ class Freebox_OS extends eqLogic
 						foreach ($Equipement->getCmd('info') as $Command) {
 							$result = $FreeboxAPI->getHomeAdapterStatus($Command->getLogicalId());
 							if ($result != false) {
-								$Equipement->checkAndUpdateCmd($Command->getLogicalId(), $result['status']);
+								if ($result['status'] == 'active') {
+									$HomeAdapters_value = 1;
+								} else {
+									$HomeAdapters_value = 0;
+								}
+								$Equipement->checkAndUpdateCmd($Command->getLogicalId(), $HomeAdapters_value);
 							}
 						}
 						break;

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -156,11 +156,11 @@ class Freebox_OS extends eqLogic
 			'template' => 'tmplmultistate',
 			'replace' => array('#_time_widget_#' => '1'),
 			'test' => array(
-				array('operation' => "#value# == 'idle'", 'state_light' => '<i class=\'icon_green icon fas fa-unlock\'></i>'),
+				array('operation' => "#value# == 'idle'", 'state_light' => '<i class=\'icon_green icon jeedom-lock-ouvert\'></i>'),
 				array('operation' => "#value# == 'alarm2_armed'", 'state_light' => '<i class=\'icon_red icon nature-night2\'></i>'),
-				array('operation' => "#value# == 'alarm1_armed'", 'state_light' => '<i class=\'icon_red icon fas fa-lock\'></i>'),
-				array('operation' => "#value# == 'alarm_1_arming'", 'state_light' => '<i class=\'icon_orange icon fas fa-lock\'></i>'),
-				array('operation' => "#value# == 'alarm_2_arming'", 'state_light' => '<i class=\'icon_orange icon fas fa-lock\'></i>'),
+				array('operation' => "#value# == 'alarm1_armed'", 'state_light' => '<i class=\'icon_red icon jeedom-lock-ferme\'></i>'),
+				array('operation' => "#value# == 'alarm_1_arming'", 'state_light' => '<i class=\'icon_orange icon jeedom-lock-partiel\'></i>'),
+				array('operation' => "#value# == 'alarm_2_arming'", 'state_light' => '<i class=\'icon_orange icon jeedom-lock-partiel\'></i>'),
 				array('operation' => "#value# == 'alarm1_alert_timer'", 'state_light' => '<i class=\'icon_red icon far fa-clock\'></i>'),
 				array('operation' => "#value# == 'alarm2_alert_timer'", 'state_light' => '<i class=\'icon_red icon far fa-clock\'></i>'),
 				array('operation' => "#value# == 'alert'", 'state_light' => '<i class=\'icon_red icon jeedom-alerte2\'></i>')
@@ -282,13 +282,13 @@ class Freebox_OS extends eqLogic
 								$icon = 'fas fa-arrow-down';
 								$order = 4;
 							} elseif ($Command['name'] == 'alarm1') {
-								$icon = 'icon fas fa-lock icon_red';
+								$icon = 'icon jeedom-lock-ferme icon_red';
 								$order = 6;
 							} elseif ($Command['name'] == 'alarm2') {
 								$icon = 'icon nature-night2 icon_red';
 								$order = 7;
 							} elseif ($Command['name'] == 'off') {
-								$icon = 'icon fas fa-unlock icon_green';
+								$icon = 'icon jeedom-lock-ouvert icon_green';
 								$order = 8;
 							} elseif ($Command['name'] == 'skip') {
 								$IsVisible = 0;

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -262,6 +262,10 @@ class Freebox_OS extends eqLogic
 						$parameter['name'] = $Command['label'];
 						$parameter['id'] = $Command['ep_id'];
 						$parameter['url'] = $Command['value'];
+						log::add('Freebox_OS', 'debug', '┌───────── Caméra trouvée pour l\'équipement FREEBOX : ' . $parameter['name']);
+						log::add('Freebox_OS', 'debug', '│ Id : ' . $parameter['id']);
+						log::add('Freebox_OS', 'debug', '│ URL : ' . $parameter['url']);
+						log::add('Freebox_OS', 'debug', '└─────────');
 						event::add('Freebox_OS::camera', json_encode($parameter));
 						continue;
 					}

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -138,7 +138,6 @@ class Freebox_OS extends eqLogic
 		);
 
 		// Template pour le wifi info
-		//$return = array('info' => array('binary' => array()));
 		$return['info']['binary']['Wifi'] = array(
 			'template' => 'tmplicon',
 			'display' => array(
@@ -152,7 +151,6 @@ class Freebox_OS extends eqLogic
 		);
 
 		// Template pour l'état de l'alarme'
-		//$return = array('info' => array('string' => array()));
 		$return['info']['string']['Alarme Freebox'] = array(
 			'template' => 'tmplmultistate',
 			'replace' => array('#_time_widget_#' => '1'),
@@ -225,7 +223,6 @@ class Freebox_OS extends eqLogic
 	{
 		$FreeboxAPI = new FreeboxAPI();
 		self::AddEqLogic('Home Adapters', 'HomeAdapters', 'default', false, null, null);
-		//$_logicalId_OLD = null;
 		if (version_compare(jeedom::version(), "4", "<")) {
 			log::add('Freebox_OS', 'debug', '│ Application des Widgets ou Icônes pour le core V3 ');
 			$templatecore_V4 = null;
@@ -269,12 +266,7 @@ class Freebox_OS extends eqLogic
 						continue;
 					}
 					if (!is_object($Tile)) continue;
-					//	if ($Equipement['node_id'] == $_logicalId_OLD) {
-					//log::add('Freebox_OS', 'debug', '┌───────── ');
-					//	} else {
 					log::add('Freebox_OS', 'debug', '┌───────── Commande trouvée pour l\'équipement FREEBOX : ' . $Equipement['label'] . ' (Node ID ' . $Equipement['node_id'] . ')');
-					//		$_logicalId_OLD = $Equipement['node_id'];
-					//	}
 					$Command['label'] = preg_replace('/É+/', 'E', $Command['label']); // Suppression É
 					$Command['label'] = preg_replace('/\'+/', ' ', $Command['label']); // Suppression '
 					log::add('Freebox_OS', 'debug', '│ Label : ' . $Command['label'] . ' -- Name : ' . $Command['name']);
@@ -670,7 +662,7 @@ class Freebox_OS extends eqLogic
 			$TemplateWifiOnOFF = 'Freebox_OS::Wifi';
 			$iconeWfiOn = 'fas fa-wifi icon_green';
 			$iconeWfiOff = 'fas fa-times icon_red';
-			$updateiconeWifi = true; // Temporaire le temps de la migration JAG 20200621
+			$updateiconeWifi = false;
 		};
 		$Wifi = self::AddEqLogic('Wifi', 'Wifi', 'default', false, null, null);
 		$StatusWifi = $Wifi->AddCommand('Status du wifi', 'wifiStatut', "info", 'binary', $TemplateWifiStatut, null, null, 0, '', '', '', '', 0, 'default', 'default', 'default', 1, '0', $updateiconeWifi);
@@ -1118,9 +1110,9 @@ class Freebox_OS extends eqLogic
 }
 class Freebox_OSCmd extends cmd
 {
-	//public function dontRemoveCmd(){
-	//	return true;
-	//}
+	/*public function dontRemoveCmd(){
+		return true;
+	}*/
 	public function execute($_options = array())
 	{
 		log::add('Freebox_OS', 'debug', '>───────── Connexion sur la freebox pour mise à jour de : ' . $this->getName());

--- a/desktop/php/Freebox_OS.php
+++ b/desktop/php/Freebox_OS.php
@@ -196,6 +196,14 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                 <a class="btn btn-primary eqLogicAction"><i class="fas fa-search"></i> {{Recherche}}</a>
                             </div>
                         </div>
+                        <div class="form-group">
+                            <label class="col-sm-2 control-label">{{logicalId}}
+                                <sup><i class="fas fa-question-circle" title="{{logicalId Freebox}}"></i></sup>
+                            </label>
+                            <div class="col-sm-3">
+                                <span class="eqLogicAttr tooltips label label-default" data-l1key="configuration" data-l2key="logicalID"></span>
+                            </div>
+                        </div>
                         <div class="form-group Equipement_tiles">
                             <label class="col-sm-2 control-label">{{Type équipement}}
                                 <sup><i class="fas fa-question-circle" title="{{Type équipement Freebox}}"></i></sup>


### PR DESCRIPTION
- Résolution bug transparence équipement réseau + disques
- Résolution bug Etat HomeAdapters
- Compatibilité avec la V3 pour certains icônes
- Aligmement icônes des commandes de l'alarme en fonction du plugin Alarme
- **Caméra**
  - Ajout de log lors de la création
  - Modification du réglage de la caméra lors de la création de l'équipement dans le **_Plugin Caméra_** cela permettra une meilleure intégration dans Homebridge.
    > Attention le réglage n'est pas changé dans l'équipement existant.
    >
    > - Soit il faut supprimer l'équipement et relancer un scan des Tiles
    > - Soit modifier les réglages suivants :
    >   - **URL du Flux** : rtsp://#username#:#password#@#ip#/img/live
    >   - **Nombre d'images par seconde de la vidéo** _(onglet capture)_ : 15