### PR TITLE
Bugs + Amélioration

### DIFF
--- a/core/ajax/Freebox_OS.ajax.php
+++ b/core/ajax/Freebox_OS.ajax.php
@@ -34,7 +34,7 @@ try {
 				$EqLogic->setconfiguration("username", $username);
 				$EqLogic->setconfiguration("password", $password);
 				$EqLogic->setconfiguration("videoFramerate", 15);
-				$EqLogic->setconfiguration("applyDevice", "Freebox.RocketCam");
+				$EqLogic->setconfiguration("device", "rocketcam");
 				$URL_snaphot = "img/snapshot.cgi?size=4&quality=1";
 				$EqLogic->setconfiguration("urlStream", $URL_snaphot);
 				$URLrtsp = init('url');

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -732,9 +732,9 @@ class Freebox_OS extends eqLogic
 			$updateiconeWifi = false;
 		};
 		$Wifi = self::AddEqLogic('Wifi', 'Wifi', 'default', false, null, null);
-		$StatusWifi = $Wifi->AddCommand('Status du wifi', 'wifiStatut', "info", 'binary', $TemplateWifiStatut, null, null, 0, '', '', '', '', 0, 'default', 'default', 1, 1, $updateiconeWifi, true);
-		$Wifi->AddCommand('Wifi On', 'wifiOn', 'action', 'other', $TemplateWifiOnOFF, null, null, 1, $StatusWifi, 'wifiStatut', 0, $iconeWfiOn, 0, 'default', 'default', 3, '0', $updateiconeWifi, false);
-		$Wifi->AddCommand('Wifi Off', 'wifiOff', 'action', 'other', $TemplateWifiOnOFF, null, null, 1, $StatusWifi, 'wifiStatut', 0, $iconeWfiOff, 0, 'default', 'default', 4, '0', $updateiconeWifi, false);
+		$StatusWifi = $Wifi->AddCommand('Status du wifi', 'wifiStatut', "info", 'binary', $TemplateWifiStatut, null, 'ENERGY_STATE', 0, '', '', '', '', 0, 'default', 'default', 1, 1, $updateiconeWifi, true);
+		$Wifi->AddCommand('Wifi On', 'wifiOn', 'action', 'other', $TemplateWifiOnOFF, null, 'ENERGY_ON', 1, $StatusWifi, 'wifiStatut', 0, $iconeWfiOn, 0, 'default', 'default', 3, '0', $updateiconeWifi, false);
+		$Wifi->AddCommand('Wifi Off', 'wifiOff', 'action', 'other', $TemplateWifiOnOFF, null, 'ENERGY_OFF', 1, $StatusWifi, 'wifiStatut', 0, $iconeWfiOff, 0, 'default', 'default', 4, '0', $updateiconeWifi, false);
 		$Wifi->AddCommand('Active Désactive le wifi', 'wifiOnOff', 'action', 'other', null, null, null, 0, $StatusWifi, 'wifiStatut', 0, null, 0, 'default', 'default', 2, '0', $updateiconeWifi, false);
 
 		log::add('Freebox_OS', 'debug', '└─────────');
@@ -1369,8 +1369,8 @@ class Freebox_OSCmd extends cmd
 							}
 
 							break;
-						} else if ($this->getConfiguration('equipement') == 'alarm_control' && ($this->getLogicalId() == 1 || $this->getLogicalId() == 2 || $this->getLogicalId() == 4)) {
-							/*log::add('Freebox_OS', 'debug', '│ Paramétrage spécifique  Activation / Désactivation Alarme : ' . $this->getLogicalId());
+							/*} else if ($this->getConfiguration('equipement') == 'alarm_control' && ($this->getLogicalId() == 1 || $this->getLogicalId() == 2 || $this->getLogicalId() == 4)) {
+							log::add('Freebox_OS', 'debug', '│ Paramétrage spécifique  Activation / Désactivation Alarme : ' . $this->getLogicalId());
 							if ($this->getLogicalId() == 1 || $this->getLogicalId() == 2) {
 								$Alarm_actif = 1;
 							} else {

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -320,7 +320,6 @@ class Freebox_OS extends eqLogic
 								$_iconname = 1;
 								$order = 6;
 								$_home_mode_set = 'SetModeAbsent';
-								$_home_mode = 'Mode Jour';
 							} elseif ($Command['name'] == 'alarm2' && $Equipement['type'] = 'alarm_control') {
 								$generic_type = 'ALARM_SET_MODE';
 								$icon = 'icon nature-night2 icon_red';
@@ -328,7 +327,6 @@ class Freebox_OS extends eqLogic
 								$_iconname = 1;
 								$order = 7;
 								$_home_mode_set = 'SetModeNuit';
-								$_home_mode = 'Mode Nuit';
 							} elseif ($Command['name'] == 'off' && $Equipement['type'] = 'alarm_control') {
 								$generic_type = 'ALARM_RELEASED';
 								$icon = 'icon jeedom-lock-ouvert icon_green';
@@ -339,7 +337,7 @@ class Freebox_OS extends eqLogic
 								$IsVisible = 0;
 								$order = 9;
 							}
-							$action = $Tile->AddCommand($Command['label'], $Command['ep_id'], 'action', 'other', null, $Command['ui']['unit'], $generic_type, $IsVisible, $Link_I, $Link_I, 0, $icon, 0, 'default', 'default', $order, 0, false, false, $Equipement['type'], $_iconname, $_home_mode_set, $_home_mode);
+							$action = $Tile->AddCommand($Command['label'], $Command['ep_id'], 'action', 'other', null, $Command['ui']['unit'], $generic_type, $IsVisible, $Link_I, $Link_I, 0, $icon, 0, 'default', 'default', $order, 0, false, false, $Equipement['type'], $_iconname, $_home_mode_set);
 							break;
 						case "int":
 							foreach (str_split($Command['ui']['access']) as $access) {
@@ -542,7 +540,7 @@ class Freebox_OS extends eqLogic
 		}
 	}
 
-	public function AddCommand($Name, $_logicalId, $Type = 'info', $SubType = 'binary', $Template = null, $unite = null, $generic_type = null, $IsVisible = 1, $link_I = 'default', $link_logicalId = 'default',  $invertBinary = '0', $icon, $forceLineB = '0', $valuemin = 'default', $valuemax = 'default', $_order = null, $IsHistorized = '0', $forceIcone_widget = false, $repeatevent = false, $_Equipement = null, $_iconname = null, $_home_mode_set = null, $_home_mode = null)
+	public function AddCommand($Name, $_logicalId, $Type = 'info', $SubType = 'binary', $Template = null, $unite = null, $generic_type = null, $IsVisible = 1, $link_I = 'default', $link_logicalId = 'default',  $invertBinary = '0', $icon, $forceLineB = '0', $valuemin = 'default', $valuemax = 'default', $_order = null, $IsHistorized = '0', $forceIcone_widget = false, $repeatevent = false, $_Equipement = null, $_iconname = null, $_home_mode_set = null)
 	{
 		log::add('Freebox_OS', 'debug', '│ Name: ' . $Name . ' -- Type : ' . $Type . ' -- LogicalID : ' . $_logicalId . ' -- Template Widget / Ligne : ' . $Template . '/' . $forceLineB . '-- Type de générique : ' . $generic_type . ' -- Inverser : ' . $invertBinary . ' -- Icône : ' . $icon . ' -- Min/Max : ' . $valuemin . '/' . $valuemax);
 
@@ -592,15 +590,15 @@ class Freebox_OS extends eqLogic
 
 			$Command->save();
 		}
-		if ($_home_mode_set != null) { // Compatibilité Homebride
-			$this->setconfiguration($_home_mode_set, $Command->getId() . "|" . $_home_mode);
+		if ($_home_mode_set != null) { // Compatibilité Homebridge
+			$this->setconfiguration($_home_mode_set, $Command->getId() . "|" . $VerifName);
 			$this->save(true);
-			if ($_home_mode_set = 'SetModeAbsent') {
+			if ($_home_mode_set == 'SetModeAbsent') {
 				$this->setConfiguration('SetModePresent', "NOT");
-				$this->save(true);
+			} else {
+				$this->setconfiguration($_home_mode_set, $Command->getId() . "|" . $VerifName);
 			}
 			log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Set Mode : ' . $_home_mode_set);
-			log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Mode : ' . $_home_mode);
 		}
 		if ($repeatevent == true && $Type == 'info') {
 			$Command->setconfiguration('repeatEventManagement', 'never');

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -568,10 +568,6 @@ class Freebox_OS extends eqLogic
 			if ($unite != null && $SubType == 'numeric') {
 				$Command->setUnite($unite);
 			}
-			if ($generic_type != null) {
-				$Command->setGeneric_type($generic_type);
-			}
-
 			$Command->setIsVisible($IsVisible);
 			$Command->setIsHistorized($IsHistorized);
 
@@ -589,6 +585,9 @@ class Freebox_OS extends eqLogic
 			}
 
 			$Command->save();
+		}
+		if ($generic_type != null) {
+			$Command->setGeneric_type($generic_type);
 		}
 		if ($_home_mode_set != null) { // Compatibilité Homebridge
 			$this->setconfiguration($_home_mode_set, $Command->getId() . "|" . $VerifName);

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -594,8 +594,10 @@ class Freebox_OS extends eqLogic
 		}
 		if ($_home_mode_set != null) { // Compatibilité Homebride
 			$this->setconfiguration($_home_mode_set, $Command->getId() . "|" . $_home_mode);
+			$this->save(true)
 			if ($_home_mode_set = 'SetModeAbsent') {
 				$this->setConfiguration('SetModePresent', "NOT");
+				$this->save(true)
 			}
 			log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Set Mode : ' . $_home_mode_set);
 			log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Mode : ' . $_home_mode);

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -594,10 +594,10 @@ class Freebox_OS extends eqLogic
 		}
 		if ($_home_mode_set != null) { // Compatibilité Homebride
 			$this->setconfiguration($_home_mode_set, $Command->getId() . "|" . $_home_mode);
-			$this->save(true)
+			$this->save(true);
 			if ($_home_mode_set = 'SetModeAbsent') {
 				$this->setConfiguration('SetModePresent', "NOT");
-				$this->save(true)
+				$this->save(true);
 			}
 			log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Set Mode : ' . $_home_mode_set);
 			log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Mode : ' . $_home_mode);

--- a/core/class/Freebox_OS.class.php
+++ b/core/class/Freebox_OS.class.php
@@ -319,7 +319,7 @@ class Freebox_OS extends eqLogic
 								$Link_I = $Link_I_ALARM;
 								$_iconname = 1;
 								$order = 6;
-								$_home_mode_set = 'SetModePresent';
+								$_home_mode_set = 'SetModeAbsent';
 								$_home_mode = 'Mode Jour';
 							} elseif ($Command['name'] == 'alarm2' && $Equipement['type'] = 'alarm_control') {
 								$generic_type = 'ALARM_SET_MODE';
@@ -589,14 +589,17 @@ class Freebox_OS extends eqLogic
 			if ($_iconname != null) {
 				$Command->setdisplay('showIconAndNamedashboard', 1);
 			}
-			if ($_home_mode_set != null) { // Compatibilité Homebride
-				$Command->setconfiguration($_home_mode_set, $Command->getId() . "|" . $_home_mode);
-				log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Set Mode : ' . $_home_mode_set);
-				log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Mode : ' . $_home_mode);
-			}
+
 			$Command->save();
 		}
-
+		if ($_home_mode_set != null) { // Compatibilité Homebride
+			$this->setconfiguration($_home_mode_set, $Command->getId() . "|" . $_home_mode);
+			if ($_home_mode_set = 'SetModeAbsent') {
+				$this->setConfiguration('SetModePresent', "NOT");
+			}
+			log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Set Mode : ' . $_home_mode_set);
+			log::add('Freebox_OS', 'debug', '│ Paramétrage du Mode Homebridge Mode : ' . $_home_mode);
+		}
 		if ($repeatevent == true && $Type == 'info') {
 			$Command->setconfiguration('repeatEventManagement', 'never');
 			log::add('Freebox_OS', 'debug', '│ No Repeat pour l\'info avec le nom : ' . $Name);


### PR DESCRIPTION
- Correction type device Camera add Plugin
- Correction Bug widget Alarme Freebox
- Nettoyage Création des commandes
- Ajout icône pour les batteries
- Début de la compatibilité de l'alarme avec Homebridge
- Modification de la répétition des infos
- Ajout possibilité dans l'add des commandes de mettre le nom avec son icône
- Ajout du type d'équipement sur chaque commande
- Ajout type de générique pour le Wifi