### PR TITLE
Corrige le soucis d'affichage sur les téléchargements

### DIFF
--- a/desktop/modal/authentification.php
+++ b/desktop/modal/authentification.php
@@ -281,7 +281,7 @@ if (!isConnect('admin')) {
                         <tr>
                             <td><b>VM</b></td>
                             <td id="vm" class="alert-danger">NOK</td>
-                            <td>{{Contrôle de la VM</td>
+                            <td>{{Contrôle de la VM}}</td>
                             <td><b>Download</b></td>
                             <td id="downloader" class="alert-danger">NOK</td>
                             <td>{{Accès au gestionnaire de téléchargements}}</td>


### PR DESCRIPTION
Les accolades ne sont pas fermées sur l'objet précédent "Download".

Voir ma capture d'écran avant cette modification :
<img width="1110" alt="Capture d’écran 2021-05-28 à 13 13 12" src="https://user-images.githubusercontent.com/676032/119977313-8f0fd800-bfb8-11eb-8dfb-0b6193efb7f9.png">
